### PR TITLE
Revert "chore(deps): update helm release external-dns to v1.15.2 - autoclosed"

### DIFF
--- a/cluster/cloud-cluster/core/external-dns.yaml
+++ b/cluster/cloud-cluster/core/external-dns.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 1.15.2
+      version: 1.15.0
       sourceRef:
         kind: HelmRepository
         name: external-dns

--- a/cluster/kube-system/external-dns.yaml
+++ b/cluster/kube-system/external-dns.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 1.15.2
+      version: 1.15.0
       sourceRef:
         kind: HelmRepository
         name: external-dns


### PR DESCRIPTION
Reverts samcday/home-cluster#1020

https://github.com/kubernetes-sigs/external-dns/issues/5035